### PR TITLE
Rename packages to singular form

### DIFF
--- a/pkg/hypercube/hypercubeset.go
+++ b/pkg/hypercube/hypercubeset.go
@@ -1,23 +1,23 @@
-package hypercubes
+package hypercube
 
 import (
 	"errors"
 	"sort"
 	"strings"
 
-	"github.com/np-guard/models/pkg/intervals"
+	"github.com/np-guard/models/pkg/interval"
 )
 
 // CanonicalHypercubeSet is a canonical representation for set of n-dimensional cubes, from integer intervals
 type CanonicalHypercubeSet struct {
-	layers     map[*intervals.CanonicalIntervalSet]*CanonicalHypercubeSet
+	layers     map[*interval.CanonicalIntervalSet]*CanonicalHypercubeSet
 	dimensions int
 }
 
 // NewCanonicalHypercubeSet returns a new empty CanonicalHypercubeSet with n dimensions
 func NewCanonicalHypercubeSet(n int) *CanonicalHypercubeSet {
 	return &CanonicalHypercubeSet{
-		layers:     map[*intervals.CanonicalIntervalSet]*CanonicalHypercubeSet{},
+		layers:     map[*interval.CanonicalIntervalSet]*CanonicalHypercubeSet{},
 		dimensions: n,
 	}
 }
@@ -54,7 +54,7 @@ func (c *CanonicalHypercubeSet) Union(other *CanonicalHypercubeSet) *CanonicalHy
 		return nil
 	}
 	res := NewCanonicalHypercubeSet(c.dimensions)
-	remainingsFromOther := map[*intervals.CanonicalIntervalSet]*intervals.CanonicalIntervalSet{}
+	remainingsFromOther := map[*interval.CanonicalIntervalSet]*interval.CanonicalIntervalSet{}
 	for k := range other.layers {
 		kCopy := k.Copy()
 		remainingsFromOther[k] = &kCopy
@@ -152,8 +152,8 @@ func (c *CanonicalHypercubeSet) Subtraction(other *CanonicalHypercubeSet) *Canon
 	return res
 }
 
-func (c *CanonicalHypercubeSet) getIntervalSetUnion() *intervals.CanonicalIntervalSet {
-	res := intervals.NewCanonicalIntervalSet()
+func (c *CanonicalHypercubeSet) getIntervalSetUnion() *interval.CanonicalIntervalSet {
+	res := interval.NewCanonicalIntervalSet()
 	for k := range c.layers {
 		res.Union(*k)
 	}
@@ -209,7 +209,7 @@ func (c *CanonicalHypercubeSet) Copy() *CanonicalHypercubeSet {
 	return res
 }
 
-func getCubeStr(cube []*intervals.CanonicalIntervalSet) string {
+func getCubeStr(cube []*interval.CanonicalIntervalSet) string {
 	strList := []string{}
 	for _, v := range cube {
 		strList = append(strList, "("+v.String()+")")
@@ -229,18 +229,18 @@ func (c *CanonicalHypercubeSet) String() string {
 }
 
 // GetCubesList returns the list of cubes in c, each cube as a slice of CanonicalIntervalSet
-func (c *CanonicalHypercubeSet) GetCubesList() [][]*intervals.CanonicalIntervalSet {
-	res := [][]*intervals.CanonicalIntervalSet{}
+func (c *CanonicalHypercubeSet) GetCubesList() [][]*interval.CanonicalIntervalSet {
+	res := [][]*interval.CanonicalIntervalSet{}
 	if c.dimensions == 1 {
 		for k := range c.layers {
-			res = append(res, []*intervals.CanonicalIntervalSet{k})
+			res = append(res, []*interval.CanonicalIntervalSet{k})
 		}
 		return res
 	}
 	for k, v := range c.layers {
 		subRes := v.GetCubesList()
 		for _, subList := range subRes {
-			cube := []*intervals.CanonicalIntervalSet{k}
+			cube := []*interval.CanonicalIntervalSet{k}
 			cube = append(cube, subList...)
 			res = append(res, cube)
 		}
@@ -250,18 +250,18 @@ func (c *CanonicalHypercubeSet) GetCubesList() [][]*intervals.CanonicalIntervalS
 
 func (c *CanonicalHypercubeSet) applyElementsUnionPerLayer() {
 	type pair struct {
-		hc *CanonicalHypercubeSet            // hypercube set object
-		is []*intervals.CanonicalIntervalSet // interval-set list
+		hc *CanonicalHypercubeSet           // hypercube set object
+		is []*interval.CanonicalIntervalSet // interval-set list
 	}
 	equivClasses := map[string]*pair{}
 	for k, v := range c.layers {
 		if _, ok := equivClasses[v.String()]; ok {
 			equivClasses[v.String()].is = append(equivClasses[v.String()].is, k)
 		} else {
-			equivClasses[v.String()] = &pair{hc: v, is: []*intervals.CanonicalIntervalSet{k}}
+			equivClasses[v.String()] = &pair{hc: v, is: []*interval.CanonicalIntervalSet{k}}
 		}
 	}
-	newLayers := map[*intervals.CanonicalIntervalSet]*CanonicalHypercubeSet{}
+	newLayers := map[*interval.CanonicalIntervalSet]*CanonicalHypercubeSet{}
 	for _, p := range equivClasses {
 		newVal := p.hc
 		newKey := p.is[0]
@@ -275,7 +275,7 @@ func (c *CanonicalHypercubeSet) applyElementsUnionPerLayer() {
 
 // CreateFromCube returns a new CanonicalHypercubeSet created from a single input cube
 // the input cube is a slice of CanonicalIntervalSet, treated as ordered list of dimension values
-func CreateFromCube(cube []*intervals.CanonicalIntervalSet) *CanonicalHypercubeSet {
+func CreateFromCube(cube []*interval.CanonicalIntervalSet) *CanonicalHypercubeSet {
 	if len(cube) == 0 {
 		return nil
 	}
@@ -291,7 +291,7 @@ func CreateFromCube(cube []*intervals.CanonicalIntervalSet) *CanonicalHypercubeS
 	return res
 }
 
-func CreateFromCubeAsIntervals(values ...*intervals.CanonicalIntervalSet) *CanonicalHypercubeSet {
+func CreateFromCubeAsIntervals(values ...*interval.CanonicalIntervalSet) *CanonicalHypercubeSet {
 	return CreateFromCube(values)
 }
 
@@ -299,14 +299,14 @@ func CreateFromCubeAsIntervals(values ...*intervals.CanonicalIntervalSet) *Canon
 // the input cube is given as an ordered list of integer values, where each two values
 // represent the range (start,end) for a dimension value
 func CreateFromCubeShort(values ...int64) *CanonicalHypercubeSet {
-	cube := []*intervals.CanonicalIntervalSet{}
+	cube := []*interval.CanonicalIntervalSet{}
 	for i := 0; i < len(values); i += 2 {
-		cube = append(cube, intervals.CreateFromInterval(values[i], values[i+1]))
+		cube = append(cube, interval.CreateFromInterval(values[i], values[i+1]))
 	}
 	return CreateFromCube(cube)
 }
 
-func copyIntervalSet(a *intervals.CanonicalIntervalSet) *intervals.CanonicalIntervalSet {
+func copyIntervalSet(a *interval.CanonicalIntervalSet) *interval.CanonicalIntervalSet {
 	res := a.Copy()
 	return &res
 }

--- a/pkg/hypercube/hypercubeset_test.go
+++ b/pkg/hypercube/hypercubeset_test.go
@@ -1,11 +1,11 @@
-package hypercubes_test
+package hypercube_test
 
 import (
 	"fmt"
 	"testing"
 
-	"github.com/np-guard/models/pkg/hypercubes"
-	"github.com/np-guard/models/pkg/intervals"
+	"github.com/np-guard/models/pkg/hypercube"
+	intervals "github.com/np-guard/models/pkg/interval"
 )
 
 func TestHCbasic(t *testing.T) {
@@ -16,12 +16,12 @@ func TestHCbasic(t *testing.T) {
 	cube5 := []*intervals.CanonicalIntervalSet{intervals.CreateFromInterval(1, 100), intervals.CreateFromInterval(1, 100)}
 	cube6 := []*intervals.CanonicalIntervalSet{intervals.CreateFromInterval(1, 100), intervals.CreateFromInterval(1, 200)}
 
-	a := hypercubes.CreateFromCube(cube1)
-	b := hypercubes.CreateFromCube(cube2)
-	c := hypercubes.CreateFromCube(cube3)
-	d := hypercubes.CreateFromCube(cube4)
-	e := hypercubes.CreateFromCube(cube5)
-	f := hypercubes.CreateFromCube(cube6)
+	a := hypercube.CreateFromCube(cube1)
+	b := hypercube.CreateFromCube(cube2)
+	c := hypercube.CreateFromCube(cube3)
+	d := hypercube.CreateFromCube(cube4)
+	e := hypercube.CreateFromCube(cube5)
+	f := hypercube.CreateFromCube(cube6)
 
 	if !a.Equals(b) {
 		t.FailNow()
@@ -58,7 +58,7 @@ func TestHCbasic(t *testing.T) {
 
 func TestCopy(t *testing.T) {
 	cube1 := []*intervals.CanonicalIntervalSet{intervals.CreateFromInterval(1, 100)}
-	a := hypercubes.CreateFromCube(cube1)
+	a := hypercube.CreateFromCube(cube1)
 	b := a.Copy()
 	if !a.Equals(b) {
 		t.FailNow()
@@ -74,8 +74,8 @@ func TestCopy(t *testing.T) {
 func TestString(t *testing.T) {
 	cube1 := []*intervals.CanonicalIntervalSet{intervals.CreateFromInterval(1, 100)}
 	cube2 := []*intervals.CanonicalIntervalSet{intervals.CreateFromInterval(1, 100), intervals.CreateFromInterval(1, 100)}
-	a := hypercubes.CreateFromCube(cube1)
-	b := hypercubes.CreateFromCube(cube2)
+	a := hypercube.CreateFromCube(cube1)
+	b := hypercube.CreateFromCube(cube2)
 	fmt.Println(a.String())
 	fmt.Println(b.String())
 	fmt.Println("done")
@@ -84,8 +84,8 @@ func TestString(t *testing.T) {
 func TestOr(t *testing.T) {
 	cube1 := []*intervals.CanonicalIntervalSet{intervals.CreateFromInterval(1, 100), intervals.CreateFromInterval(1, 100)}
 	cube2 := []*intervals.CanonicalIntervalSet{intervals.CreateFromInterval(1, 90), intervals.CreateFromInterval(1, 200)}
-	a := hypercubes.CreateFromCube(cube1)
-	b := hypercubes.CreateFromCube(cube2)
+	a := hypercube.CreateFromCube(cube1)
+	b := hypercube.CreateFromCube(cube2)
 	c := a.Union(b)
 	fmt.Println(a.String())
 	fmt.Println(b.String())
@@ -93,33 +93,33 @@ func TestOr(t *testing.T) {
 	fmt.Println("done")
 }
 
-func addCube1Dim(o *hypercubes.CanonicalHypercubeSet, start, end int64) *hypercubes.CanonicalHypercubeSet {
+func addCube1Dim(o *hypercube.CanonicalHypercubeSet, start, end int64) *hypercube.CanonicalHypercubeSet {
 	cube := []*intervals.CanonicalIntervalSet{intervals.CreateFromInterval(start, end)}
-	a := hypercubes.CreateFromCube(cube)
+	a := hypercube.CreateFromCube(cube)
 	return o.Union(a)
 }
 
-func addCube2Dim(o *hypercubes.CanonicalHypercubeSet, start1, end1, start2, end2 int64) *hypercubes.CanonicalHypercubeSet {
+func addCube2Dim(o *hypercube.CanonicalHypercubeSet, start1, end1, start2, end2 int64) *hypercube.CanonicalHypercubeSet {
 	cube := []*intervals.CanonicalIntervalSet{intervals.CreateFromInterval(start1, end1), intervals.CreateFromInterval(start2, end2)}
-	a := hypercubes.CreateFromCube(cube)
+	a := hypercube.CreateFromCube(cube)
 	return o.Union(a)
 }
 
-func addCube3Dim(o *hypercubes.CanonicalHypercubeSet, s1, e1, s2, e2, s3, e3 int64) *hypercubes.CanonicalHypercubeSet {
+func addCube3Dim(o *hypercube.CanonicalHypercubeSet, s1, e1, s2, e2, s3, e3 int64) *hypercube.CanonicalHypercubeSet {
 	cube := []*intervals.CanonicalIntervalSet{
 		intervals.CreateFromInterval(s1, e1),
 		intervals.CreateFromInterval(s2, e2),
 		intervals.CreateFromInterval(s3, e3)}
-	a := hypercubes.CreateFromCube(cube)
+	a := hypercube.CreateFromCube(cube)
 	return o.Union(a)
 }
 
 func TestBasic(t *testing.T) {
-	a := hypercubes.NewCanonicalHypercubeSet(1)
+	a := hypercube.NewCanonicalHypercubeSet(1)
 	a = addCube1Dim(a, 1, 2)
 	a = addCube1Dim(a, 5, 6)
 	a = addCube1Dim(a, 3, 4)
-	b := hypercubes.NewCanonicalHypercubeSet(1)
+	b := hypercube.NewCanonicalHypercubeSet(1)
 	b = addCube1Dim(b, 1, 6)
 	if !a.Equals(b) {
 		t.FailNow()
@@ -127,11 +127,11 @@ func TestBasic(t *testing.T) {
 }
 
 func TestBasic2(t *testing.T) {
-	a := hypercubes.NewCanonicalHypercubeSet(2)
+	a := hypercube.NewCanonicalHypercubeSet(2)
 	a = addCube2Dim(a, 1, 2, 1, 5)
 	a = addCube2Dim(a, 1, 2, 7, 9)
 	a = addCube2Dim(a, 1, 2, 6, 7)
-	b := hypercubes.NewCanonicalHypercubeSet(2)
+	b := hypercube.NewCanonicalHypercubeSet(2)
 	b = addCube2Dim(b, 1, 2, 1, 9)
 	if !a.Equals(b) {
 		t.FailNow()
@@ -139,7 +139,7 @@ func TestBasic2(t *testing.T) {
 }
 
 func TestNew(t *testing.T) {
-	a := hypercubes.NewCanonicalHypercubeSet(3)
+	a := hypercube.NewCanonicalHypercubeSet(3)
 	a = addCube3Dim(a, 10, 20, 10, 20, 1, 65535)
 	a = addCube3Dim(a, 1, 65535, 15, 40, 1, 65535)
 	a = addCube3Dim(a, 1, 65535, 100, 200, 30, 80)
@@ -153,7 +153,7 @@ func TestNew(t *testing.T) {
 	fmt.Println("done")
 }
 
-func checkContained(t *testing.T, a, b *hypercubes.CanonicalHypercubeSet, expected bool) {
+func checkContained(t *testing.T, a, b *hypercube.CanonicalHypercubeSet, expected bool) {
 	t.Helper()
 	contained, err := a.ContainedIn(b)
 	if contained != expected || err != nil {
@@ -161,7 +161,7 @@ func checkContained(t *testing.T, a, b *hypercubes.CanonicalHypercubeSet, expect
 	}
 }
 
-func checkEquals(t *testing.T, a, b *hypercubes.CanonicalHypercubeSet, expected bool) {
+func checkEquals(t *testing.T, a, b *hypercube.CanonicalHypercubeSet, expected bool) {
 	t.Helper()
 	res := a.Equals(b)
 	if res != expected {
@@ -170,29 +170,29 @@ func checkEquals(t *testing.T, a, b *hypercubes.CanonicalHypercubeSet, expected 
 }
 
 func TestContainedIn(t *testing.T) {
-	a := hypercubes.CreateFromCubeShort(1, 100, 200, 300)
-	b := hypercubes.CreateFromCubeShort(10, 80, 210, 280)
+	a := hypercube.CreateFromCubeShort(1, 100, 200, 300)
+	b := hypercube.CreateFromCubeShort(10, 80, 210, 280)
 	checkContained(t, b, a, true)
 	b = addCube2Dim(b, 10, 200, 210, 280)
 	checkContained(t, b, a, false)
 }
 
 func TestContainedIn2(t *testing.T) {
-	c := hypercubes.CreateFromCubeShort(1, 100, 200, 300)
+	c := hypercube.CreateFromCubeShort(1, 100, 200, 300)
 	c = addCube2Dim(c, 150, 180, 20, 300)
 	c = addCube2Dim(c, 200, 240, 200, 300)
 	c = addCube2Dim(c, 241, 300, 200, 350)
 
-	a := hypercubes.CreateFromCubeShort(1, 100, 200, 300)
+	a := hypercube.CreateFromCubeShort(1, 100, 200, 300)
 	a = addCube2Dim(a, 150, 180, 20, 300)
 	a = addCube2Dim(a, 200, 240, 200, 300)
 	a = addCube2Dim(a, 242, 300, 200, 350)
 
-	d := hypercubes.CreateFromCubeShort(210, 220, 210, 280)
-	e := hypercubes.CreateFromCubeShort(210, 310, 210, 280)
-	f := hypercubes.CreateFromCubeShort(210, 250, 210, 280)
-	f1 := hypercubes.CreateFromCubeShort(210, 240, 210, 280)
-	f2 := hypercubes.CreateFromCubeShort(241, 250, 210, 280)
+	d := hypercube.CreateFromCubeShort(210, 220, 210, 280)
+	e := hypercube.CreateFromCubeShort(210, 310, 210, 280)
+	f := hypercube.CreateFromCubeShort(210, 250, 210, 280)
+	f1 := hypercube.CreateFromCubeShort(210, 240, 210, 280)
+	f2 := hypercube.CreateFromCubeShort(241, 250, 210, 280)
 
 	checkContained(t, d, c, true)
 	checkContained(t, e, c, false)
@@ -203,8 +203,8 @@ func TestContainedIn2(t *testing.T) {
 }
 
 func TestContainedIn3(t *testing.T) {
-	a := hypercubes.CreateFromCubeShort(105, 105, 54, 54)
-	b := hypercubes.CreateFromCubeShort(0, 204, 0, 255)
+	a := hypercube.CreateFromCubeShort(105, 105, 54, 54)
+	b := hypercube.CreateFromCubeShort(0, 204, 0, 255)
 	b = addCube2Dim(b, 205, 205, 0, 53)
 	b = addCube2Dim(b, 205, 205, 55, 255)
 	b = addCube2Dim(b, 206, 254, 0, 255)
@@ -212,107 +212,107 @@ func TestContainedIn3(t *testing.T) {
 }
 
 func TestContainedIn4(t *testing.T) {
-	a := hypercubes.CreateFromCubeShort(105, 105, 54, 54)
-	b := hypercubes.CreateFromCubeShort(200, 204, 0, 255)
+	a := hypercube.CreateFromCubeShort(105, 105, 54, 54)
+	b := hypercube.CreateFromCubeShort(200, 204, 0, 255)
 	checkContained(t, a, b, false)
 }
 
 func TestContainedIn5(t *testing.T) {
-	a := hypercubes.CreateFromCubeShort(100, 200, 54, 65, 60, 300)
-	b := hypercubes.CreateFromCubeShort(110, 120, 0, 10, 0, 255)
+	a := hypercube.CreateFromCubeShort(100, 200, 54, 65, 60, 300)
+	b := hypercube.CreateFromCubeShort(110, 120, 0, 10, 0, 255)
 	checkContained(t, b, a, false)
 }
 
 func TestEquals(t *testing.T) {
-	a := hypercubes.CreateFromCubeShort(1, 2)
-	b := hypercubes.CreateFromCubeShort(1, 2)
+	a := hypercube.CreateFromCubeShort(1, 2)
+	b := hypercube.CreateFromCubeShort(1, 2)
 	checkEquals(t, a, b, true)
-	c := hypercubes.CreateFromCubeShort(1, 2, 1, 5)
-	d := hypercubes.CreateFromCubeShort(1, 2, 1, 5)
+	c := hypercube.CreateFromCubeShort(1, 2, 1, 5)
+	d := hypercube.CreateFromCubeShort(1, 2, 1, 5)
 	checkEquals(t, c, d, true)
 	c = addCube2Dim(c, 1, 2, 7, 9)
 	c = addCube2Dim(c, 1, 2, 6, 7)
 	c = addCube2Dim(c, 4, 8, 1, 9)
-	res := hypercubes.CreateFromCubeShort(4, 8, 1, 9)
+	res := hypercube.CreateFromCubeShort(4, 8, 1, 9)
 	res = addCube2Dim(res, 1, 2, 1, 9)
 	checkEquals(t, res, c, true)
 
 	a = addCube1Dim(a, 5, 6)
 	a = addCube1Dim(a, 3, 4)
-	res1 := hypercubes.CreateFromCubeShort(1, 6)
+	res1 := hypercube.CreateFromCubeShort(1, 6)
 	checkEquals(t, res1, a, true)
 
 	d = addCube2Dim(d, 1, 2, 1, 5)
 	d = addCube2Dim(d, 5, 6, 1, 5)
 	d = addCube2Dim(d, 3, 4, 1, 5)
-	res2 := hypercubes.CreateFromCubeShort(1, 6, 1, 5)
+	res2 := hypercube.CreateFromCubeShort(1, 6, 1, 5)
 	checkEquals(t, res2, d, true)
 }
 
 func TestBasicAddCube(t *testing.T) {
-	a := hypercubes.CreateFromCubeShort(1, 2)
+	a := hypercube.CreateFromCubeShort(1, 2)
 	a = addCube1Dim(a, 8, 10)
 	b := a
 	a = addCube1Dim(a, 1, 2)
 	a = addCube1Dim(a, 6, 10)
 	a = addCube1Dim(a, 1, 10)
-	res := hypercubes.CreateFromCubeShort(1, 10)
+	res := hypercube.CreateFromCubeShort(1, 10)
 	checkEquals(t, res, a, true)
 	checkEquals(t, res, b, false)
 }
 func TestBasicAddHole(t *testing.T) {
-	a := hypercubes.CreateFromCubeShort(1, 10)
-	b := a.Subtraction(hypercubes.CreateFromCubeShort(3, 20))
-	c := a.Subtraction(hypercubes.CreateFromCubeShort(0, 20))
-	d := a.Subtraction(hypercubes.CreateFromCubeShort(0, 5))
-	e := a.Subtraction(hypercubes.CreateFromCubeShort(12, 14))
-	a = a.Subtraction(hypercubes.CreateFromCubeShort(3, 7))
-	f := hypercubes.CreateFromCubeShort(1, 2)
+	a := hypercube.CreateFromCubeShort(1, 10)
+	b := a.Subtraction(hypercube.CreateFromCubeShort(3, 20))
+	c := a.Subtraction(hypercube.CreateFromCubeShort(0, 20))
+	d := a.Subtraction(hypercube.CreateFromCubeShort(0, 5))
+	e := a.Subtraction(hypercube.CreateFromCubeShort(12, 14))
+	a = a.Subtraction(hypercube.CreateFromCubeShort(3, 7))
+	f := hypercube.CreateFromCubeShort(1, 2)
 	f = addCube1Dim(f, 8, 10)
 	checkEquals(t, a, f, true)
-	checkEquals(t, b, hypercubes.CreateFromCubeShort(1, 2), true)
-	checkEquals(t, c, hypercubes.NewCanonicalHypercubeSet(1), true)
-	checkEquals(t, d, hypercubes.CreateFromCubeShort(6, 10), true)
-	checkEquals(t, e, hypercubes.CreateFromCubeShort(1, 10), true)
+	checkEquals(t, b, hypercube.CreateFromCubeShort(1, 2), true)
+	checkEquals(t, c, hypercube.NewCanonicalHypercubeSet(1), true)
+	checkEquals(t, d, hypercube.CreateFromCubeShort(6, 10), true)
+	checkEquals(t, e, hypercube.CreateFromCubeShort(1, 10), true)
 }
 
 func TestAddHoleBasic2(t *testing.T) {
-	a := hypercubes.CreateFromCubeShort(1, 100, 200, 300)
+	a := hypercube.CreateFromCubeShort(1, 100, 200, 300)
 	b := a.Copy()
 	c := a.Copy()
-	a = a.Subtraction(hypercubes.CreateFromCubeShort(50, 60, 220, 300))
-	resA := hypercubes.CreateFromCubeShort(61, 100, 200, 300)
+	a = a.Subtraction(hypercube.CreateFromCubeShort(50, 60, 220, 300))
+	resA := hypercube.CreateFromCubeShort(61, 100, 200, 300)
 	resA = addCube2Dim(resA, 50, 60, 200, 219)
 	resA = addCube2Dim(resA, 1, 49, 200, 300)
 	checkEquals(t, a, resA, true)
 
-	b = b.Subtraction(hypercubes.CreateFromCubeShort(50, 1000, 0, 250))
-	resB := hypercubes.CreateFromCubeShort(50, 100, 251, 300)
+	b = b.Subtraction(hypercube.CreateFromCubeShort(50, 1000, 0, 250))
+	resB := hypercube.CreateFromCubeShort(50, 100, 251, 300)
 	resB = addCube2Dim(resB, 1, 49, 200, 300)
 	checkEquals(t, b, resB, true)
 
 	c = addCube2Dim(c, 400, 700, 200, 300)
-	c = c.Subtraction(hypercubes.CreateFromCubeShort(50, 1000, 0, 250))
-	resC := hypercubes.CreateFromCubeShort(50, 100, 251, 300)
+	c = c.Subtraction(hypercube.CreateFromCubeShort(50, 1000, 0, 250))
+	resC := hypercube.CreateFromCubeShort(50, 100, 251, 300)
 	resC = addCube2Dim(resC, 1, 49, 200, 300)
 	resC = addCube2Dim(resC, 400, 700, 251, 300)
 	checkEquals(t, c, resC, true)
 }
 
 func TestAddHole(t *testing.T) {
-	c := hypercubes.CreateFromCubeShort(1, 100, 200, 300)
-	c = c.Subtraction(hypercubes.CreateFromCubeShort(50, 60, 220, 300))
-	d := hypercubes.CreateFromCubeShort(1, 49, 200, 300)
+	c := hypercube.CreateFromCubeShort(1, 100, 200, 300)
+	c = c.Subtraction(hypercube.CreateFromCubeShort(50, 60, 220, 300))
+	d := hypercube.CreateFromCubeShort(1, 49, 200, 300)
 	d = addCube2Dim(d, 50, 60, 200, 219)
 	d = addCube2Dim(d, 61, 100, 200, 300)
 	checkEquals(t, c, d, true)
 }
 
 func TestAddHole2(t *testing.T) {
-	c := hypercubes.CreateFromCubeShort(80, 100, 20, 300)
+	c := hypercube.CreateFromCubeShort(80, 100, 20, 300)
 	c = addCube2Dim(c, 250, 400, 20, 300)
-	c = c.Subtraction(hypercubes.CreateFromCubeShort(30, 300, 100, 102))
-	d := hypercubes.CreateFromCubeShort(80, 100, 20, 99)
+	c = c.Subtraction(hypercube.CreateFromCubeShort(30, 300, 100, 102))
+	d := hypercube.CreateFromCubeShort(80, 100, 20, 99)
 	d = addCube2Dim(d, 80, 100, 103, 300)
 	d = addCube2Dim(d, 250, 300, 20, 99)
 	d = addCube2Dim(d, 250, 300, 103, 300)
@@ -320,15 +320,15 @@ func TestAddHole2(t *testing.T) {
 	checkEquals(t, c, d, true)
 }
 func TestAddHole3(t *testing.T) {
-	c := hypercubes.CreateFromCubeShort(1, 100, 200, 300)
-	c = c.Subtraction(hypercubes.CreateFromCubeShort(1, 100, 200, 300))
-	checkEquals(t, c, hypercubes.NewCanonicalHypercubeSet(2), true)
+	c := hypercube.CreateFromCubeShort(1, 100, 200, 300)
+	c = c.Subtraction(hypercube.CreateFromCubeShort(1, 100, 200, 300))
+	checkEquals(t, c, hypercube.NewCanonicalHypercubeSet(2), true)
 }
 
 func TestIntervalsUnion(t *testing.T) {
-	c := hypercubes.CreateFromCubeShort(1, 100, 200, 300)
+	c := hypercube.CreateFromCubeShort(1, 100, 200, 300)
 	c = addCube2Dim(c, 101, 200, 200, 300)
-	d := hypercubes.CreateFromCubeShort(1, 200, 200, 300)
+	d := hypercube.CreateFromCubeShort(1, 200, 200, 300)
 	checkEquals(t, c, d, true)
 	if c.String() != d.String() {
 		t.FailNow()
@@ -336,7 +336,7 @@ func TestIntervalsUnion(t *testing.T) {
 }
 
 func TestIntervalsUnion2(t *testing.T) {
-	c := hypercubes.CreateFromCubeShort(1, 100, 200, 300)
+	c := hypercube.CreateFromCubeShort(1, 100, 200, 300)
 	c = addCube2Dim(c, 101, 200, 200, 300)
 	c = addCube2Dim(c, 201, 300, 200, 300)
 	c = addCube2Dim(c, 301, 400, 200, 300)
@@ -347,7 +347,7 @@ func TestIntervalsUnion2(t *testing.T) {
 	d := c.Copy()
 	d = addCube2Dim(d, 702, 800, 200, 700)
 
-	cExpected := hypercubes.CreateFromCubeShort(1, 400, 200, 300)
+	cExpected := hypercube.CreateFromCubeShort(1, 400, 200, 300)
 	cExpected = addCube2Dim(cExpected, 402, 500, 200, 300)
 	cExpected = addCube2Dim(cExpected, 500, 700, 200, 700)
 	dExpected := cExpected.Copy()
@@ -357,38 +357,38 @@ func TestIntervalsUnion2(t *testing.T) {
 }
 
 func TestAndSubOr(t *testing.T) {
-	a := hypercubes.CreateFromCubeShort(5, 15, 3, 10)
-	b := hypercubes.CreateFromCubeShort(8, 30, 7, 20)
+	a := hypercube.CreateFromCubeShort(5, 15, 3, 10)
+	b := hypercube.CreateFromCubeShort(8, 30, 7, 20)
 
 	c := a.Intersection(b)
-	d := hypercubes.CreateFromCubeShort(8, 15, 7, 10)
+	d := hypercube.CreateFromCubeShort(8, 15, 7, 10)
 	checkEquals(t, c, d, true)
 
 	f := a.Union(b)
-	e := hypercubes.CreateFromCubeShort(5, 15, 3, 6)
+	e := hypercube.CreateFromCubeShort(5, 15, 3, 6)
 	e = addCube2Dim(e, 5, 30, 7, 10)
 	e = addCube2Dim(e, 8, 30, 11, 20)
 	checkEquals(t, e, f, true)
 
 	g := a.Subtraction(b)
-	h := hypercubes.CreateFromCubeShort(5, 7, 3, 10)
+	h := hypercube.CreateFromCubeShort(5, 7, 3, 10)
 	h = addCube2Dim(h, 8, 15, 3, 6)
 	checkEquals(t, g, h, true)
 }
 
 func TestAnd2(t *testing.T) {
-	a := hypercubes.CreateFromCubeShort(5, 15, 3, 10)
-	b := hypercubes.CreateFromCubeShort(1, 3, 7, 20)
+	a := hypercube.CreateFromCubeShort(5, 15, 3, 10)
+	b := hypercube.CreateFromCubeShort(1, 3, 7, 20)
 	b = addCube2Dim(b, 20, 23, 7, 20)
 	c := a.Intersection(b)
-	checkEquals(t, c, hypercubes.NewCanonicalHypercubeSet(2), true)
+	checkEquals(t, c, hypercube.NewCanonicalHypercubeSet(2), true)
 }
 
 func TestOr2(t *testing.T) {
-	a := hypercubes.CreateFromCubeShort(80, 100, 10053, 10053)
-	b := hypercubes.CreateFromCubeShort(1, 65535, 10054, 10054)
+	a := hypercube.CreateFromCubeShort(80, 100, 10053, 10053)
+	b := hypercube.CreateFromCubeShort(1, 65535, 10054, 10054)
 	a = a.Union(b)
-	expected := hypercubes.CreateFromCubeShort(1, 79, 10054, 10054)
+	expected := hypercube.CreateFromCubeShort(1, 79, 10054, 10054)
 	expected = addCube2Dim(expected, 80, 100, 10053, 10054)
 	expected = addCube2Dim(expected, 101, 65535, 10054, 10054)
 	checkEquals(t, a, expected, true)

--- a/pkg/interval/interval.go
+++ b/pkg/interval/interval.go
@@ -1,4 +1,4 @@
-package intervals
+package interval
 
 import "fmt"
 

--- a/pkg/interval/intervalset.go
+++ b/pkg/interval/intervalset.go
@@ -1,4 +1,4 @@
-package intervals
+package interval
 
 import (
 	"fmt"

--- a/pkg/interval/intervalset_test.go
+++ b/pkg/interval/intervalset_test.go
@@ -1,17 +1,17 @@
-package intervals_test
+package interval_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/np-guard/models/pkg/intervals"
+	"github.com/np-guard/models/pkg/interval"
 )
 
 func TestInterval(t *testing.T) {
-	it1 := intervals.Interval{3, 7}
-	it2 := intervals.Interval{3, 5}
-	it3 := intervals.Interval{2, 7}
+	it1 := interval.Interval{3, 7}
+	it2 := interval.Interval{3, 5}
+	it3 := interval.Interval{2, 7}
 
 	require.Equal(t, "[3-7]", it1.String())
 
@@ -20,18 +20,18 @@ func TestInterval(t *testing.T) {
 }
 
 func TestIntervalSet(t *testing.T) {
-	is1 := intervals.NewCanonicalIntervalSet()
-	is1.AddInterval(intervals.Interval{5, 10})
-	is1.AddInterval(intervals.Interval{0, 1})
-	is1.AddInterval(intervals.Interval{3, 3})
-	is1.AddInterval(intervals.Interval{70, 80})
-	is1.AddHole(intervals.Interval{7, 9})
+	is1 := interval.NewCanonicalIntervalSet()
+	is1.AddInterval(interval.Interval{5, 10})
+	is1.AddInterval(interval.Interval{0, 1})
+	is1.AddInterval(interval.Interval{3, 3})
+	is1.AddInterval(interval.Interval{70, 80})
+	is1.AddHole(interval.Interval{7, 9})
 	require.True(t, is1.Contains(5))
 	require.False(t, is1.Contains(8))
 
-	is2 := intervals.NewCanonicalIntervalSet()
+	is2 := interval.NewCanonicalIntervalSet()
 	require.Equal(t, "Empty", is2.String())
-	is2.AddInterval(intervals.Interval{6, 8})
+	is2.AddInterval(interval.Interval{6, 8})
 	require.Equal(t, "6-8", is2.String())
 	require.False(t, is2.IsSingleNumber())
 	require.False(t, is2.ContainedIn(*is1))
@@ -48,7 +48,7 @@ func TestIntervalSet(t *testing.T) {
 	require.False(t, is2.Overlaps(is1))
 
 	is1.Union(*is2)
-	is1.Union(*intervals.CreateFromInterval(7, 9))
+	is1.Union(*interval.CreateFromInterval(7, 9))
 	require.True(t, is2.ContainedIn(*is1))
 	require.False(t, is1.ContainedIn(*is2))
 	require.True(t, is1.Overlaps(is2))
@@ -59,5 +59,5 @@ func TestIntervalSet(t *testing.T) {
 	require.True(t, is3.Equal(*is2))
 	require.True(t, is2.ContainedIn(is3))
 
-	require.True(t, intervals.CreateFromInterval(1, 1).IsSingleNumber())
+	require.True(t, interval.CreateFromInterval(1, 1).IsSingleNumber())
 }

--- a/pkg/ipblock/ipblock.go
+++ b/pkg/ipblock/ipblock.go
@@ -1,4 +1,4 @@
-package ipblocks
+package ipblock
 
 import (
 	"encoding/binary"
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/np-guard/models/pkg/intervals"
+	"github.com/np-guard/models/pkg/interval"
 )
 
 const (
@@ -33,7 +33,7 @@ const (
 
 // IPBlock captures a set of IP ranges
 type IPBlock struct {
-	ipRange intervals.CanonicalIntervalSet
+	ipRange interval.CanonicalIntervalSet
 }
 
 // ToIPRanges returns a string of the ip ranges in the current IPBlock object
@@ -42,7 +42,7 @@ func (b *IPBlock) ToIPRanges() string {
 }
 
 // toIPRange returns a string of the ip range of a single interval
-func toIPRange(i intervals.Interval) string {
+func toIPRange(i interval.Interval) string {
 	startIP := inttoIP4(i.Start)
 	endIP := inttoIP4(i.End)
 	return rangeIPstr(startIP, endIP)
@@ -120,7 +120,7 @@ func (b *IPBlock) Split() []*IPBlock {
 	res := make([]*IPBlock, len(b.ipRange.IntervalSet))
 	for index, ipr := range b.ipRange.IntervalSet {
 		newBlock := IPBlock{}
-		newBlock.ipRange.IntervalSet = append(newBlock.ipRange.IntervalSet, intervals.Interval{Start: ipr.Start, End: ipr.End})
+		newBlock.ipRange.IntervalSet = append(newBlock.ipRange.IntervalSet, interval.Interval{Start: ipr.Start, End: ipr.End})
 		res[index] = &newBlock
 	}
 	return res
@@ -211,7 +211,7 @@ func NewIPBlockFromCidrOrAddress(s string) (*IPBlock, error) {
 
 // NewIPBlockFromCidrList returns IPBlock object from multiple CIDRs given as list of strings
 func NewIPBlockFromCidrList(cidrsList []string) (*IPBlock, error) {
-	res := &IPBlock{ipRange: intervals.CanonicalIntervalSet{}}
+	res := &IPBlock{ipRange: interval.CanonicalIntervalSet{}}
 	for _, cidr := range cidrsList {
 		block, err := NewIPBlockFromCidr(cidr)
 		if err != nil {
@@ -224,12 +224,12 @@ func NewIPBlockFromCidrList(cidrsList []string) (*IPBlock, error) {
 
 // NewIPBlock returns an IPBlock object from input cidr str an exceptions cidr str
 func NewIPBlock(cidr string, exceptions []string) (*IPBlock, error) {
-	res := IPBlock{ipRange: intervals.CanonicalIntervalSet{}}
-	interval, err := cidrToInterval(cidr)
+	res := IPBlock{ipRange: interval.CanonicalIntervalSet{}}
+	span, err := cidrToInterval(cidr)
 	if err != nil {
 		return nil, err
 	}
-	res.ipRange.AddInterval(*interval)
+	res.ipRange.AddInterval(*span)
 	for i := range exceptions {
 		intervalHole, err := cidrToInterval(exceptions[i])
 		if err != nil {
@@ -267,12 +267,12 @@ func cidrToIPRange(cidr string) (start, end int64, err error) {
 	return
 }
 
-func cidrToInterval(cidr string) (*intervals.Interval, error) {
+func cidrToInterval(cidr string) (*interval.Interval, error) {
 	start, end, err := cidrToIPRange(cidr)
 	if err != nil {
 		return nil, err
 	}
-	return &intervals.Interval{Start: start, End: end}, nil
+	return &interval.Interval{Start: start, End: end}, nil
 }
 
 // ToCidrList returns a list of CIDR strings for this IPBlock object
@@ -353,10 +353,10 @@ func IPBlockFromIPRangeStr(ipRagneStr string) (*IPBlock, error) {
 		return nil, err
 	}
 	res := &IPBlock{}
-	res.ipRange = intervals.CanonicalIntervalSet{IntervalSet: []intervals.Interval{}}
+	res.ipRange = interval.CanonicalIntervalSet{IntervalSet: []interval.Interval{}}
 	startIPNum := startIP.ipRange.IntervalSet[0].Start
 	endIPNum := endIP.ipRange.IntervalSet[0].Start
-	res.ipRange.IntervalSet = append(res.ipRange.IntervalSet, intervals.Interval{Start: startIPNum, End: endIPNum})
+	res.ipRange.IntervalSet = append(res.ipRange.IntervalSet, interval.Interval{Start: startIPNum, End: endIPNum})
 	return res, nil
 }
 


### PR DESCRIPTION
This is part of #10.

`interval` is imported as `intervals` in hypercube_test so that git sees it as a move and not as a delete.