### PR TITLE
Cleanup hypercube tests

### DIFF
--- a/pkg/hypercube/hypercubeset.go
+++ b/pkg/hypercube/hypercubeset.go
@@ -298,14 +298,3 @@ func FromCube(cube []*interval.CanonicalSet) *CanonicalSet {
 	res.layers[cube[0].Copy()] = FromCube(cube[1:])
 	return res
 }
-
-// FromCubeShort returns a new CanonicalSet created from a single input cube
-// the input cube is given as an ordered list of integer values, where each two values
-// represent the range (start,end) for a dimension value
-func FromCubeShort(values ...int64) *CanonicalSet {
-	cube := []*interval.CanonicalSet{}
-	for i := 0; i < len(values); i += 2 {
-		cube = append(cube, interval.FromInterval(values[i], values[i+1]))
-	}
-	return FromCube(cube)
-}

--- a/pkg/hypercube/hypercubeset_test.go
+++ b/pkg/hypercube/hypercubeset_test.go
@@ -1,198 +1,143 @@
 package hypercube_test
 
 import (
-	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/np-guard/models/pkg/hypercube"
 	"github.com/np-guard/models/pkg/interval"
 )
 
+// cube returns a new hypercube.CanonicalSet created from a single input cube
+// the input cube is given as an ordered list of integer values, where each two values
+// represent the range (start,end) for a dimension value
+func cube(values ...int64) *hypercube.CanonicalSet {
+	cube := []*interval.CanonicalSet{}
+	for i := 0; i < len(values); i += 2 {
+		cube = append(cube, interval.FromInterval(values[i], values[i+1]))
+	}
+	return hypercube.FromCube(cube)
+}
+
+func union(set *hypercube.CanonicalSet, sets ...*hypercube.CanonicalSet) *hypercube.CanonicalSet {
+	for _, c := range sets {
+		set = set.Union(c)
+	}
+	return set.Copy()
+}
+
 func TestHCBasic(t *testing.T) {
-	cube1 := []*interval.CanonicalSet{interval.FromInterval(1, 100)}
-	cube2 := []*interval.CanonicalSet{interval.FromInterval(1, 100)}
-	cube3 := []*interval.CanonicalSet{interval.FromInterval(1, 200)}
-	cube4 := []*interval.CanonicalSet{interval.FromInterval(1, 100), interval.FromInterval(1, 100)}
-	cube5 := []*interval.CanonicalSet{interval.FromInterval(1, 100), interval.FromInterval(1, 100)}
-	cube6 := []*interval.CanonicalSet{interval.FromInterval(1, 100), interval.FromInterval(1, 200)}
+	a := cube(1, 100)
+	b := cube(1, 100)
+	c := cube(1, 200)
+	d := cube(1, 100, 1, 100)
+	e := cube(1, 100, 1, 100)
+	f := cube(1, 100, 1, 200)
 
-	a := hypercube.FromCube(cube1)
-	b := hypercube.FromCube(cube2)
-	c := hypercube.FromCube(cube3)
-	d := hypercube.FromCube(cube4)
-	e := hypercube.FromCube(cube5)
-	f := hypercube.FromCube(cube6)
+	require.True(t, a.Equal(b))
+	require.True(t, b.Equal(a))
 
-	if !a.Equal(b) {
-		t.FailNow()
-	}
-	if a.Equal(c) {
-		t.FailNow()
-	}
-	if b.Equal(c) {
-		t.FailNow()
-	}
-	//nolint:all
-	/*if !c.Equal(c) {
-		t.FailNow()
-	}
-	if !a.Equal(a) {
-		t.FailNow()
-	}
-	if !b.Equal(b) {
-		t.FailNow()
-	}*/
-	if !d.Equal(e) {
-		t.FailNow()
-	}
-	if !e.Equal(d) {
-		t.FailNow()
-	}
-	if d.Equal(f) {
-		t.FailNow()
-	}
-	if f.Equal(d) {
-		t.FailNow()
-	}
+	require.False(t, a.Equal(c))
+	require.False(t, c.Equal(a))
+
+	require.False(t, a.Equal(d))
+	require.False(t, d.Equal(a))
+
+	require.True(t, d.Equal(e))
+	require.True(t, e.Equal(d))
+
+	require.False(t, d.Equal(f))
+	require.False(t, f.Equal(d))
 }
 
 func TestCopy(t *testing.T) {
-	cube1 := []*interval.CanonicalSet{interval.FromInterval(1, 100)}
-	a := hypercube.FromCube(cube1)
+	a := cube(1, 100)
 	b := a.Copy()
-	if !a.Equal(b) {
-		t.FailNow()
-	}
-	if !b.Equal(a) {
-		t.FailNow()
-	}
-	if a == b {
-		t.FailNow()
-	}
+	require.True(t, a.Equal(b))
+	require.True(t, b.Equal(a))
+	require.True(t, a != b)
 }
 
 func TestString(t *testing.T) {
-	cube1 := []*interval.CanonicalSet{interval.FromInterval(1, 100)}
-	cube2 := []*interval.CanonicalSet{interval.FromInterval(1, 100), interval.FromInterval(1, 100)}
-	a := hypercube.FromCube(cube1)
-	b := hypercube.FromCube(cube2)
-	fmt.Println(a.String())
-	fmt.Println(b.String())
-	fmt.Println("done")
+	require.Equal(t, "[(1-3)]", cube(1, 3).String())
+	require.Equal(t, "[(1-3),(2-4)]", cube(1, 3, 2, 4).String())
 }
 
 func TestOr(t *testing.T) {
-	cube1 := []*interval.CanonicalSet{interval.FromInterval(1, 100), interval.FromInterval(1, 100)}
-	cube2 := []*interval.CanonicalSet{interval.FromInterval(1, 90), interval.FromInterval(1, 200)}
-	a := hypercube.FromCube(cube1)
-	b := hypercube.FromCube(cube2)
+	a := cube(1, 100, 1, 100)
+	b := cube(1, 90, 1, 200)
 	c := a.Union(b)
-	fmt.Println(a.String())
-	fmt.Println(b.String())
-	fmt.Println(c.String())
-	fmt.Println("done")
+	require.Equal(t, "[(1-90),(1-200)]; [(91-100),(1-100)]", c.String())
 }
 
-func addCube1Dim(o *hypercube.CanonicalSet, start, end int64) *hypercube.CanonicalSet {
-	cube := []*interval.CanonicalSet{interval.FromInterval(start, end)}
-	a := hypercube.FromCube(cube)
-	return o.Union(a)
-}
-
-func addCube2Dim(o *hypercube.CanonicalSet, start1, end1, start2, end2 int64) *hypercube.CanonicalSet {
-	cube := []*interval.CanonicalSet{interval.FromInterval(start1, end1), interval.FromInterval(start2, end2)}
-	a := hypercube.FromCube(cube)
-	return o.Union(a)
-}
-
-func addCube3Dim(o *hypercube.CanonicalSet, s1, e1, s2, e2, s3, e3 int64) *hypercube.CanonicalSet {
-	cube := []*interval.CanonicalSet{
-		interval.FromInterval(s1, e1),
-		interval.FromInterval(s2, e2),
-		interval.FromInterval(s3, e3)}
-	a := hypercube.FromCube(cube)
-	return o.Union(a)
-}
-
-func TestBasic(t *testing.T) {
-	a := hypercube.NewCanonicalSet(1)
-	a = addCube1Dim(a, 1, 2)
-	a = addCube1Dim(a, 5, 6)
-	a = addCube1Dim(a, 3, 4)
-	b := hypercube.NewCanonicalSet(1)
-	b = addCube1Dim(b, 1, 6)
-	if !a.Equal(b) {
-		t.FailNow()
-	}
+func TestBasic1(t *testing.T) {
+	a := union(
+		cube(1, 2),
+		cube(5, 6),
+		cube(3, 4),
+	)
+	b := cube(1, 6)
+	require.True(t, a.Equal(b))
 }
 
 func TestBasic2(t *testing.T) {
-	a := hypercube.NewCanonicalSet(2)
-	a = addCube2Dim(a, 1, 2, 1, 5)
-	a = addCube2Dim(a, 1, 2, 7, 9)
-	a = addCube2Dim(a, 1, 2, 6, 7)
-	b := hypercube.NewCanonicalSet(2)
-	b = addCube2Dim(b, 1, 2, 1, 9)
-	if !a.Equal(b) {
-		t.FailNow()
-	}
+	a := union(
+		cube(1, 2, 1, 5),
+		cube(1, 2, 7, 9),
+		cube(1, 2, 6, 7),
+	)
+	b := cube(1, 2, 1, 9)
+	require.True(t, a.Equal(b))
 }
 
 func TestNew(t *testing.T) {
-	a := hypercube.NewCanonicalSet(3)
-	a = addCube3Dim(a, 10, 20, 10, 20, 1, 65535)
-	a = addCube3Dim(a, 1, 65535, 15, 40, 1, 65535)
-	a = addCube3Dim(a, 1, 65535, 100, 200, 30, 80)
-	expectedStr := "[(1-9,21-65535),(100-200),(30-80)]; [(1-9,21-65535),(15-40),(1-65535)]"
-	expectedStr += "; [(10-20),(10-40),(1-65535)]; [(10-20),(100-200),(30-80)]"
-	actualStr := a.String()
-	if actualStr != expectedStr {
-		t.FailNow()
-	}
-	fmt.Println(a.String())
-	fmt.Println("done")
+	a := union(
+		cube(10, 20, 10, 20, 1, 65535),
+		cube(1, 65535, 15, 40, 1, 65535),
+		cube(1, 65535, 100, 200, 30, 80),
+	)
+	expectedStr := "[(1-9,21-65535),(100-200),(30-80)]; " +
+		"[(1-9,21-65535),(15-40),(1-65535)]; " +
+		"[(10-20),(10-40),(1-65535)]; " +
+		"[(10-20),(100-200),(30-80)]"
+	require.Equal(t, expectedStr, a.String())
 }
 
 func checkContained(t *testing.T, a, b *hypercube.CanonicalSet, expected bool) {
 	t.Helper()
 	contained, err := a.ContainedIn(b)
-	if contained != expected || err != nil {
-		t.FailNow()
-	}
-}
-
-func checkEqual(t *testing.T, a, b *hypercube.CanonicalSet, expected bool) {
-	t.Helper()
-	res := a.Equal(b)
-	if res != expected {
-		t.FailNow()
-	}
+	require.Nil(t, err)
+	require.Equal(t, expected, contained)
 }
 
 func TestContainedIn(t *testing.T) {
-	a := hypercube.FromCubeShort(1, 100, 200, 300)
-	b := hypercube.FromCubeShort(10, 80, 210, 280)
+	a := cube(1, 100, 200, 300)
+	b := cube(10, 80, 210, 280)
 	checkContained(t, b, a, true)
-	b = addCube2Dim(b, 10, 200, 210, 280)
+	b = b.Union(cube(10, 200, 210, 280))
 	checkContained(t, b, a, false)
 }
 
 func TestContainedIn2(t *testing.T) {
-	c := hypercube.FromCubeShort(1, 100, 200, 300)
-	c = addCube2Dim(c, 150, 180, 20, 300)
-	c = addCube2Dim(c, 200, 240, 200, 300)
-	c = addCube2Dim(c, 241, 300, 200, 350)
+	c := union(
+		cube(1, 100, 200, 300),
+		cube(150, 180, 20, 300),
+		cube(200, 240, 200, 300),
+		cube(241, 300, 200, 350),
+	)
 
-	a := hypercube.FromCubeShort(1, 100, 200, 300)
-	a = addCube2Dim(a, 150, 180, 20, 300)
-	a = addCube2Dim(a, 200, 240, 200, 300)
-	a = addCube2Dim(a, 242, 300, 200, 350)
-
-	d := hypercube.FromCubeShort(210, 220, 210, 280)
-	e := hypercube.FromCubeShort(210, 310, 210, 280)
-	f := hypercube.FromCubeShort(210, 250, 210, 280)
-	f1 := hypercube.FromCubeShort(210, 240, 210, 280)
-	f2 := hypercube.FromCubeShort(241, 250, 210, 280)
+	a := union(
+		cube(1, 100, 200, 300),
+		cube(150, 180, 20, 300),
+		cube(200, 240, 200, 300),
+		cube(242, 300, 200, 350),
+	)
+	d := cube(210, 220, 210, 280)
+	e := cube(210, 310, 210, 280)
+	f := cube(210, 250, 210, 280)
+	f1 := cube(210, 240, 210, 280)
+	f2 := cube(241, 250, 210, 280)
 
 	checkContained(t, d, c, true)
 	checkContained(t, e, c, false)
@@ -203,193 +148,227 @@ func TestContainedIn2(t *testing.T) {
 }
 
 func TestContainedIn3(t *testing.T) {
-	a := hypercube.FromCubeShort(105, 105, 54, 54)
-	b := hypercube.FromCubeShort(0, 204, 0, 255)
-	b = addCube2Dim(b, 205, 205, 0, 53)
-	b = addCube2Dim(b, 205, 205, 55, 255)
-	b = addCube2Dim(b, 206, 254, 0, 255)
+	a := cube(105, 105, 54, 54)
+	b := union(
+		cube(0, 204, 0, 255),
+		cube(205, 205, 0, 53),
+		cube(205, 205, 55, 255),
+		cube(206, 254, 0, 255),
+	)
 	checkContained(t, a, b, true)
 }
 
 func TestContainedIn4(t *testing.T) {
-	a := hypercube.FromCubeShort(105, 105, 54, 54)
-	b := hypercube.FromCubeShort(200, 204, 0, 255)
+	a := cube(105, 105, 54, 54)
+	b := cube(200, 204, 0, 255)
 	checkContained(t, a, b, false)
 }
 
 func TestContainedIn5(t *testing.T) {
-	a := hypercube.FromCubeShort(100, 200, 54, 65, 60, 300)
-	b := hypercube.FromCubeShort(110, 120, 0, 10, 0, 255)
+	a := cube(100, 200, 54, 65, 60, 300)
+	b := cube(110, 120, 0, 10, 0, 255)
 	checkContained(t, b, a, false)
 }
 
-func TestEqual(t *testing.T) {
-	a := hypercube.FromCubeShort(1, 2)
-	b := hypercube.FromCubeShort(1, 2)
-	checkEqual(t, a, b, true)
-	c := hypercube.FromCubeShort(1, 2, 1, 5)
-	d := hypercube.FromCubeShort(1, 2, 1, 5)
-	checkEqual(t, c, d, true)
-	c = addCube2Dim(c, 1, 2, 7, 9)
-	c = addCube2Dim(c, 1, 2, 6, 7)
-	c = addCube2Dim(c, 4, 8, 1, 9)
-	res := hypercube.FromCubeShort(4, 8, 1, 9)
-	res = addCube2Dim(res, 1, 2, 1, 9)
-	checkEqual(t, res, c, true)
+func TestEqual1(t *testing.T) {
+	a := cube(1, 2)
+	b := cube(1, 2)
+	require.True(t, a.Equal(b))
 
-	a = addCube1Dim(a, 5, 6)
-	a = addCube1Dim(a, 3, 4)
-	res1 := hypercube.FromCubeShort(1, 6)
-	checkEqual(t, res1, a, true)
+	c := cube(1, 2, 1, 5)
+	d := cube(1, 2, 1, 5)
+	require.True(t, c.Equal(d))
+}
 
-	d = addCube2Dim(d, 1, 2, 1, 5)
-	d = addCube2Dim(d, 5, 6, 1, 5)
-	d = addCube2Dim(d, 3, 4, 1, 5)
-	res2 := hypercube.FromCubeShort(1, 6, 1, 5)
-	checkEqual(t, res2, d, true)
+func TestEqual2(t *testing.T) {
+	c := union(
+		cube(1, 2, 1, 5),
+		cube(1, 2, 7, 9),
+		cube(1, 2, 6, 7),
+		cube(4, 8, 1, 9),
+	)
+	res := union(
+		cube(4, 8, 1, 9),
+		cube(1, 2, 1, 9),
+	)
+	require.True(t, res.Equal(c))
+
+	d := union(
+		cube(1, 2, 1, 5),
+		cube(5, 6, 1, 5),
+		cube(3, 4, 1, 5),
+	)
+	res2 := cube(1, 6, 1, 5)
+	require.True(t, res2.Equal(d))
 }
 
 func TestBasicAddCube(t *testing.T) {
-	a := hypercube.FromCubeShort(1, 2)
-	a = addCube1Dim(a, 8, 10)
-	b := a
-	a = addCube1Dim(a, 1, 2)
-	a = addCube1Dim(a, 6, 10)
-	a = addCube1Dim(a, 1, 10)
-	res := hypercube.FromCubeShort(1, 10)
-	checkEqual(t, res, a, true)
-	checkEqual(t, res, b, false)
-}
-func TestBasicAddHole(t *testing.T) {
-	a := hypercube.FromCubeShort(1, 10)
-	b := a.Subtract(hypercube.FromCubeShort(3, 20))
-	c := a.Subtract(hypercube.FromCubeShort(0, 20))
-	d := a.Subtract(hypercube.FromCubeShort(0, 5))
-	e := a.Subtract(hypercube.FromCubeShort(12, 14))
-	a = a.Subtract(hypercube.FromCubeShort(3, 7))
-	f := hypercube.FromCubeShort(1, 2)
-	f = addCube1Dim(f, 8, 10)
-	checkEqual(t, a, f, true)
-	checkEqual(t, b, hypercube.FromCubeShort(1, 2), true)
-	checkEqual(t, c, hypercube.NewCanonicalSet(1), true)
-	checkEqual(t, d, hypercube.FromCubeShort(6, 10), true)
-	checkEqual(t, e, hypercube.FromCubeShort(1, 10), true)
+	a := union(
+		cube(1, 2),
+		cube(8, 10),
+	)
+	b := union(
+		a,
+		cube(1, 2),
+		cube(6, 10),
+		cube(1, 10),
+	)
+	res := cube(1, 10)
+	require.False(t, res.Equal(a))
+	require.True(t, res.Equal(b))
 }
 
-func TestAddHoleBasic2(t *testing.T) {
-	a := hypercube.FromCubeShort(1, 100, 200, 300)
-	b := a.Copy()
-	c := a.Copy()
-	a = a.Subtract(hypercube.FromCubeShort(50, 60, 220, 300))
-	resA := hypercube.FromCubeShort(61, 100, 200, 300)
-	resA = addCube2Dim(resA, 50, 60, 200, 219)
-	resA = addCube2Dim(resA, 1, 49, 200, 300)
-	checkEqual(t, a, resA, true)
-
-	b = b.Subtract(hypercube.FromCubeShort(50, 1000, 0, 250))
-	resB := hypercube.FromCubeShort(50, 100, 251, 300)
-	resB = addCube2Dim(resB, 1, 49, 200, 300)
-	checkEqual(t, b, resB, true)
-
-	c = addCube2Dim(c, 400, 700, 200, 300)
-	c = c.Subtract(hypercube.FromCubeShort(50, 1000, 0, 250))
-	resC := hypercube.FromCubeShort(50, 100, 251, 300)
-	resC = addCube2Dim(resC, 1, 49, 200, 300)
-	resC = addCube2Dim(resC, 400, 700, 251, 300)
-	checkEqual(t, c, resC, true)
+func TestFourHoles(t *testing.T) {
+	a := cube(1, 2, 1, 2)
+	require.Equal(t, "[(1),(2)]; [(2),(1-2)]", a.Subtract(cube(1, 1, 1, 1)).String())
+	require.Equal(t, "[(1),(1)]; [(2),(1-2)]", a.Subtract(cube(1, 1, 2, 2)).String())
+	require.Equal(t, "[(1),(1-2)]; [(2),(2)]", a.Subtract(cube(2, 2, 1, 1)).String())
+	require.Equal(t, "[(1),(1-2)]; [(2),(1)]", a.Subtract(cube(2, 2, 2, 2)).String())
 }
 
-func TestAddHole(t *testing.T) {
-	c := hypercube.FromCubeShort(1, 100, 200, 300)
-	c = c.Subtract(hypercube.FromCubeShort(50, 60, 220, 300))
-	d := hypercube.FromCubeShort(1, 49, 200, 300)
-	d = addCube2Dim(d, 50, 60, 200, 219)
-	d = addCube2Dim(d, 61, 100, 200, 300)
-	checkEqual(t, c, d, true)
+func TestBasicSubtract1(t *testing.T) {
+	a := cube(1, 10)
+	require.True(t, a.Subtract(cube(3, 7)).Equal(union(cube(1, 2), cube(8, 10))))
+	require.True(t, a.Subtract(cube(3, 20)).Equal(cube(1, 2)))
+	require.True(t, a.Subtract(cube(0, 20)).IsEmpty())
+	require.True(t, a.Subtract(cube(0, 5)).Equal(cube(6, 10)))
+	require.True(t, a.Subtract(cube(12, 14)).Equal(cube(1, 10)))
+}
+
+func TestBasicSubtract2(t *testing.T) {
+	a := cube(1, 100, 200, 300).Subtract(cube(50, 60, 220, 300))
+	resA := union(
+		cube(61, 100, 200, 300),
+		cube(50, 60, 200, 219),
+		cube(1, 49, 200, 300),
+	)
+	require.True(t, a.Equal(resA))
+
+	b := cube(1, 100, 200, 300).Subtract(cube(50, 1000, 0, 250))
+	resB := union(
+		cube(50, 100, 251, 300),
+		cube(1, 49, 200, 300),
+	)
+	require.True(t, b.Equal(resB))
+
+	c := union(
+		cube(1, 100, 200, 300),
+		cube(400, 700, 200, 300),
+	).Subtract(cube(50, 1000, 0, 250))
+	resC := union(
+		cube(50, 100, 251, 300),
+		cube(1, 49, 200, 300),
+		cube(400, 700, 251, 300),
+	)
+	require.True(t, c.Equal(resC))
+
+	d := cube(1, 100, 200, 300).Subtract(cube(50, 60, 220, 300))
+	dRes := union(
+		cube(1, 49, 200, 300),
+		cube(50, 60, 200, 219),
+		cube(61, 100, 200, 300),
+	)
+	require.True(t, d.Equal(dRes))
 }
 
 func TestAddHole2(t *testing.T) {
-	c := hypercube.FromCubeShort(80, 100, 20, 300)
-	c = addCube2Dim(c, 250, 400, 20, 300)
-	c = c.Subtract(hypercube.FromCubeShort(30, 300, 100, 102))
-	d := hypercube.FromCubeShort(80, 100, 20, 99)
-	d = addCube2Dim(d, 80, 100, 103, 300)
-	d = addCube2Dim(d, 250, 300, 20, 99)
-	d = addCube2Dim(d, 250, 300, 103, 300)
-	d = addCube2Dim(d, 301, 400, 20, 300)
-	checkEqual(t, c, d, true)
-}
-func TestAddHole3(t *testing.T) {
-	c := hypercube.FromCubeShort(1, 100, 200, 300)
-	c = c.Subtract(hypercube.FromCubeShort(1, 100, 200, 300))
-	checkEqual(t, c, hypercube.NewCanonicalSet(2), true)
+	c := union(
+		cube(80, 100, 20, 300),
+		cube(250, 400, 20, 300),
+	).Subtract(cube(30, 300, 100, 102))
+	d := union(
+		cube(80, 100, 20, 99),
+		cube(80, 100, 103, 300),
+		cube(250, 300, 20, 99),
+		cube(250, 300, 103, 300),
+		cube(301, 400, 20, 300),
+	)
+	require.True(t, c.Equal(d))
 }
 
-func TestIntervalsUnion(t *testing.T) {
-	c := hypercube.FromCubeShort(1, 100, 200, 300)
-	c = addCube2Dim(c, 101, 200, 200, 300)
-	d := hypercube.FromCubeShort(1, 200, 200, 300)
-	checkEqual(t, c, d, true)
-	if c.String() != d.String() {
-		t.FailNow()
-	}
+func TestSubtractToEmpty(t *testing.T) {
+	c := cube(1, 100, 200, 300).Subtract(cube(1, 100, 200, 300))
+	require.True(t, c.IsEmpty())
 }
 
-func TestIntervalsUnion2(t *testing.T) {
-	c := hypercube.FromCubeShort(1, 100, 200, 300)
-	c = addCube2Dim(c, 101, 200, 200, 300)
-	c = addCube2Dim(c, 201, 300, 200, 300)
-	c = addCube2Dim(c, 301, 400, 200, 300)
-	c = addCube2Dim(c, 402, 500, 200, 300)
-	c = addCube2Dim(c, 500, 600, 200, 700)
-	c = addCube2Dim(c, 601, 700, 200, 700)
-
-	d := c.Copy()
-	d = addCube2Dim(d, 702, 800, 200, 700)
-
-	cExpected := hypercube.FromCubeShort(1, 400, 200, 300)
-	cExpected = addCube2Dim(cExpected, 402, 500, 200, 300)
-	cExpected = addCube2Dim(cExpected, 500, 700, 200, 700)
-	dExpected := cExpected.Copy()
-	dExpected = addCube2Dim(dExpected, 702, 800, 200, 700)
-	checkEqual(t, c, cExpected, true)
-	checkEqual(t, d, dExpected, true)
+func TestUnion1(t *testing.T) {
+	c := union(
+		cube(1, 100, 200, 300),
+		cube(101, 200, 200, 300),
+	)
+	cExpected := cube(1, 200, 200, 300)
+	require.True(t, cExpected.Equal(c))
 }
 
-func TestAndSubOr(t *testing.T) {
-	a := hypercube.FromCubeShort(5, 15, 3, 10)
-	b := hypercube.FromCubeShort(8, 30, 7, 20)
+func TestUnion2(t *testing.T) {
+	c := union(
+		cube(1, 100, 200, 300),
+		cube(101, 200, 200, 300),
+		cube(201, 300, 200, 300),
+		cube(301, 400, 200, 300),
+		cube(402, 500, 200, 300),
+		cube(500, 600, 200, 700),
+		cube(601, 700, 200, 700),
+	)
+	cExpected := union(
+		cube(1, 400, 200, 300),
+		cube(402, 500, 200, 300),
+		cube(500, 700, 200, 700),
+	)
+	require.True(t, c.Equal(cExpected))
 
+	d := c.Union(cube(702, 800, 200, 700))
+	dExpected := cExpected.Union(cube(702, 800, 200, 700))
+	require.True(t, d.Equal(dExpected))
+}
+
+func TestIntersect(t *testing.T) {
+	c := cube(5, 15, 3, 10).Intersect(cube(8, 30, 7, 20))
+	d := cube(8, 15, 7, 10)
+	require.True(t, c.Equal(d))
+}
+
+func TestUnionMerge(t *testing.T) {
+	a := union(
+		cube(5, 15, 3, 6),
+		cube(5, 30, 7, 10),
+		cube(8, 30, 11, 20),
+	)
+	excepted := union(
+		cube(5, 15, 3, 10),
+		cube(8, 30, 7, 20),
+	)
+	require.True(t, excepted.Equal(a))
+}
+
+func TestSubtract(t *testing.T) {
+	g := cube(5, 15, 3, 10).Subtract(cube(8, 30, 7, 20))
+	h := union(
+		cube(5, 7, 3, 10),
+		cube(8, 15, 3, 6),
+	)
+	require.True(t, g.Equal(h))
+}
+
+func TestIntersectEmpty(t *testing.T) {
+	a := cube(5, 15, 3, 10)
+	b := union(
+		cube(1, 3, 7, 20),
+		cube(20, 23, 7, 20),
+	)
 	c := a.Intersect(b)
-	d := hypercube.FromCubeShort(8, 15, 7, 10)
-	checkEqual(t, c, d, true)
-
-	f := a.Union(b)
-	e := hypercube.FromCubeShort(5, 15, 3, 6)
-	e = addCube2Dim(e, 5, 30, 7, 10)
-	e = addCube2Dim(e, 8, 30, 11, 20)
-	checkEqual(t, e, f, true)
-
-	g := a.Subtract(b)
-	h := hypercube.FromCubeShort(5, 7, 3, 10)
-	h = addCube2Dim(h, 8, 15, 3, 6)
-	checkEqual(t, g, h, true)
-}
-
-func TestAnd2(t *testing.T) {
-	a := hypercube.FromCubeShort(5, 15, 3, 10)
-	b := hypercube.FromCubeShort(1, 3, 7, 20)
-	b = addCube2Dim(b, 20, 23, 7, 20)
-	c := a.Intersect(b)
-	checkEqual(t, c, hypercube.NewCanonicalSet(2), true)
+	require.True(t, c.IsEmpty())
 }
 
 func TestOr2(t *testing.T) {
-	a := hypercube.FromCubeShort(80, 100, 10053, 10053)
-	b := hypercube.FromCubeShort(1, 65535, 10054, 10054)
-	a = a.Union(b)
-	expected := hypercube.FromCubeShort(1, 79, 10054, 10054)
-	expected = addCube2Dim(expected, 80, 100, 10053, 10054)
-	expected = addCube2Dim(expected, 101, 65535, 10054, 10054)
-	checkEqual(t, a, expected, true)
+	a := union(
+		cube(1, 79, 10054, 10054),
+		cube(80, 100, 10053, 10054),
+		cube(101, 65535, 10054, 10054),
+	)
+	expected := union(
+		cube(80, 100, 10053, 10053),
+		cube(1, 65535, 10054, 10054),
+	)
+	require.True(t, expected.Equal(a))
 }


### PR DESCRIPTION
Use a simple function for creating hypercubes in the test. Remove the publicly-exported FromCubeShort() that's only used from this test (and is not too short). Also make tests more self-contained.