### PR TITLE
fix icmp type and code ranges

### DIFF
--- a/pkg/connection/connectionset.go
+++ b/pkg/connection/connectionset.go
@@ -22,9 +22,9 @@ const (
 	UDPCode           = 1
 	ICMPCode          = 2
 	MinICMPType int64 = 0
-	MaxICMPType int64 = netp.InformationReply
+	MaxICMPType int64 = 254 // netp.InformationReply
 	MinICMPCode int64 = 0
-	MaxICMPCode int64 = 5
+	MaxICMPCode int64 = 255 // 5
 	minProtocol int64 = 0
 	maxProtocol int64 = 2
 	MinPort           = 1

--- a/pkg/connection/connectionset.go
+++ b/pkg/connection/connectionset.go
@@ -22,9 +22,9 @@ const (
 	UDPCode           = 1
 	ICMPCode          = 2
 	MinICMPType int64 = 0
-	MaxICMPType int64 = 254 // netp.InformationReply
+	MaxICMPType int64 = 254
 	MinICMPCode int64 = 0
-	MaxICMPCode int64 = 255 // 5
+	MaxICMPCode int64 = 255
 	minProtocol int64 = 0
 	maxProtocol int64 = 2
 	MinPort           = 1

--- a/pkg/connection/connectionset_test.go
+++ b/pkg/connection/connectionset_test.go
@@ -6,6 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 package connection_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -35,9 +36,13 @@ func TestBasicSetICMP(t *testing.T) {
 func TestICMPTypeOutOfRange(t *testing.T) {
 	c1 := connection.ICMPConnection(135, 136, connection.MinICMPCode, connection.MaxICMPCode)
 	c2 := connection.ICMPConnection(connection.MinICMPType, connection.MaxICMPType, connection.MinICMPCode, connection.MaxICMPCode)
+	union := c1.Union(c2)
+	fmt.Println(c1.String())
+	fmt.Println(c2.String())
+	fmt.Println(union.String())
 	require.Equal(t, "protocol: ICMP icmp-type: 135-136", c1.String())
 	require.Equal(t, "protocol: ICMP", c2.String())
-	require.Equal(t, "protocol: ICMP", c1.Union(c2).String())
+	require.Equal(t, "protocol: ICMP", union.String())
 }
 
 func TestBasicSetTCP(t *testing.T) {

--- a/pkg/connection/connectionset_test.go
+++ b/pkg/connection/connectionset_test.go
@@ -33,7 +33,7 @@ func TestBasicSetICMP(t *testing.T) {
 	require.Equal(t, "ICMP type: 3 code: 5", c.ShortString())
 }
 
-func TestICMPTypeOutOfRange(t *testing.T) {
+func TestICMPUnion(t *testing.T) {
 	c1 := connection.ICMPConnection(135, 136, connection.MinICMPCode, connection.MaxICMPCode)
 	c2 := connection.ICMPConnection(connection.MinICMPType, connection.MaxICMPType, connection.MinICMPCode, connection.MaxICMPCode)
 	union := c1.Union(c2)
@@ -71,14 +71,15 @@ func TestBasicSet2(t *testing.T) {
 	except2 := connection.TCPorUDPConnection(netp.ProtocolStringTCP, 1, 65535, 1, 65535)
 
 	d := connection.All().Subtract(except1).Subtract(except2)
+	fmt.Println(d.String())
+	fmt.Println(d.ShortString())
 	require.Equal(t, ""+
-		"protocol: ICMP icmp-type: 0-2,4-16; "+
-		"protocol: ICMP icmp-type: 3 icmp-code: 0-4; "+
-		"protocol: UDP", d.String())
+		"protocol: ICMP icmp-type: 0-2,4-254; "+
+		"protocol: ICMP icmp-type: 3 icmp-code: 0-4,6-255; protocol: UDP",
+		d.String())
 	require.Equal(t, ""+
-		"ICMP type: 0-2,4-16; "+
-		"ICMP type: 3 code: 0-4; "+
-		"UDP", d.ShortString())
+		"ICMP type: 0-2,4-254; ICMP type: 3 code: 0-4,6-255; UDP",
+		d.ShortString())
 }
 
 func TestBasicSet3(t *testing.T) {

--- a/pkg/connection/connectionset_test.go
+++ b/pkg/connection/connectionset_test.go
@@ -32,6 +32,14 @@ func TestBasicSetICMP(t *testing.T) {
 	require.Equal(t, "ICMP type: 3 code: 5", c.ShortString())
 }
 
+func TestICMPTypeOutOfRange(t *testing.T) {
+	c1 := connection.ICMPConnection(135, 136, connection.MinICMPCode, connection.MaxICMPCode)
+	c2 := connection.ICMPConnection(connection.MinICMPType, connection.MaxICMPType, connection.MinICMPCode, connection.MaxICMPCode)
+	require.Equal(t, "protocol: ICMP icmp-type: 135-136", c1.String())
+	require.Equal(t, "protocol: ICMP", c2.String())
+	require.Equal(t, "protocol: ICMP", c1.Union(c2).String())
+}
+
 func TestBasicSetTCP(t *testing.T) {
 	e := connection.TCPorUDPConnection(netp.ProtocolStringTCP, 1, 65535, 1, 655)
 	require.Equal(t, "protocol: TCP dst-ports: 1-655", e.String())


### PR DESCRIPTION
- Example came from a real FW rule that used ICMPv6 type 135,136, which is not supported by current model within package `netp`. (found it was generated as connection-set object of ICMP 135,136, instead of skipping unsupported icmpv6).
- No validation of type and code in `connection.ICMPConnection()`, and in `connection.Set`, resulted in strange union result which does not make sense. (description in issue #65 )
- Current fix in this PR is to use all 8-bit range values for ICMP type and code in `connection.Set`
