### PR TITLE
downgrade go version to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/np-guard/models
 
-go 1.23
+go 1.22
 
 require github.com/stretchr/testify v1.9.0
 


### PR DESCRIPTION
downgrading go-version to 1.22 seems working well
so models, latest may be integrated into other repos that can not be upgraded to go 1.23 yet